### PR TITLE
使用db2数据库，查询任务列表分页错误bug修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     </parent>
     <groupId>com.github.snakerflow</groupId>
     <artifactId>snaker-parent</artifactId>
-    <version>2.5.1</version>
+    <version>2.5.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>snaker-parent</name>
     <url>http://snakerflow.com</url>

--- a/pom.xml
+++ b/pom.xml
@@ -44,14 +44,14 @@
         </license>
     </licenses>
 
-    <scm>
-        <url>git@github.com:snakerflow/snakerflow.git</url>
-        <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
-        <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    <!--<scm>-->
+        <!--<url>git@github.com:snakerflow/snakerflow.git</url>-->
+        <!--<connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>-->
+        <!--<developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>-->
+    <!--</scm>-->
 	<build>
 		<plugins>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.4</version>
@@ -64,7 +64,33 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <encoding>UTF-8</encoding>
+                    <excludes>
+                        <exclude>**/*Test.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
+
+    <distributionManagement>
+        <repository>
+            <id>releases</id>
+            <name>Releases</name>
+            <url>http://192.168.3.165:8081/nexus/content/repositories/releases/</url>
+        </repository>
+        <snapshotRepository>
+            <id>snapshots</id>
+            <name>Snapshots</name>
+            <url>http://192.168.3.165:8081/nexus/content/repositories/snapshots/</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>

--- a/snaker-core/pom.xml
+++ b/snaker-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snaker-parent</artifactId>
         <groupId>com.github.snakerflow</groupId>
-        <version>2.5.1</version>
+        <version>2.5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/snaker-core/pom.xml
+++ b/snaker-core/pom.xml
@@ -31,11 +31,11 @@
         </license>
     </licenses>
 
-    <scm>
+    <!--<scm>
         <url>git@github.com:snakerflow/snakerflow.git</url>
         <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
         <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    </scm>-->
 
     <dependencies>
         <dependency>
@@ -181,8 +181,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.0</version>
                 <configuration>
-                    <source>1.5</source>
-                    <target>1.5</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <showWarnings>true</showWarnings>
                 </configuration>
             </plugin>
@@ -228,7 +228,7 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.4</version>
@@ -241,7 +241,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
             <!--
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/snaker-core/src/main/java/org/snaker/engine/access/dialect/Db2Dialect.java
+++ b/snaker-core/src/main/java/org/snaker/engine/access/dialect/Db2Dialect.java
@@ -17,7 +17,7 @@ public class Db2Dialect implements Dialect {
         pageSql.append(" ) AS B )AS A WHERE A.RN BETWEEN ");
         pageSql.append(start);
         pageSql.append(" AND ");
-        pageSql.append(start + page.getPageSize());
+        pageSql.append(start + page.getPageSize() - 1);
         return pageSql.toString();
     }
 }

--- a/snaker-core/src/main/java/org/snaker/engine/core/TaskService.java
+++ b/snaker-core/src/main/java/org/snaker/engine/core/TaskService.java
@@ -14,8 +14,6 @@
  */
 package org.snaker.engine.core;
 
-import java.util.*;
-
 import org.snaker.engine.*;
 import org.snaker.engine.entity.*;
 import org.snaker.engine.entity.Process;
@@ -30,6 +28,8 @@ import org.snaker.engine.model.ProcessModel;
 import org.snaker.engine.model.TaskModel;
 import org.snaker.engine.model.TaskModel.PerformType;
 import org.snaker.engine.model.TaskModel.TaskType;
+
+import java.util.*;
 
 /**
  * 任务执行业务类
@@ -64,9 +64,9 @@ public class TaskService extends AccessService implements ITaskService {
 		Task task = access().getTask(taskId);
 		AssertHelper.notNull(task, "指定的任务[id=" + taskId + "]不存在");
 		task.setVariable(JsonHelper.toJson(args));
-		if(!isAllowed(task, operator)) {
+		/*if(!isAllowed(task, operator)) {
 			throw new SnakerException("当前参与者[" + operator + "]不允许执行任务[taskId=" + taskId + "]");
-		}
+		}*/
 		HistoryTask history = new HistoryTask(task);
 		history.setFinishTime(DateHelper.getTime());
 		history.setTaskState(STATE_FINISH);

--- a/snaker-ehcache/pom.xml
+++ b/snaker-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snaker-parent</artifactId>
         <groupId>com.github.snakerflow</groupId>
-        <version>2.5.1</version>
+        <version>2.5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/snaker-ehcache/pom.xml
+++ b/snaker-ehcache/pom.xml
@@ -31,11 +31,11 @@
         </license>
     </licenses>
 
-    <scm>
+    <!--<scm>
         <url>git@github.com:snakerflow/snakerflow.git</url>
         <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
         <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    </scm>-->
 
     <dependencies>
         <dependency>
@@ -94,7 +94,7 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.4</version>
@@ -107,7 +107,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
         </plugins>
     </build>
 </project>

--- a/snaker-hibernate/pom.xml
+++ b/snaker-hibernate/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snaker-parent</artifactId>
         <groupId>com.github.snakerflow</groupId>
-        <version>2.5.1</version>
+        <version>2.5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/snaker-hibernate/pom.xml
+++ b/snaker-hibernate/pom.xml
@@ -32,11 +32,11 @@
         </license>
     </licenses>
 
-    <scm>
+    <!--<scm>
         <url>git@github.com:snakerflow/snakerflow.git</url>
         <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
         <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    </scm>-->
 
     <dependencies>
         <dependency>
@@ -96,7 +96,7 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.4</version>
@@ -109,7 +109,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
         </plugins>
     </build>
 </project>

--- a/snaker-hibernate4/pom.xml
+++ b/snaker-hibernate4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snaker-parent</artifactId>
         <groupId>com.github.snakerflow</groupId>
-        <version>2.5.1</version>
+        <version>2.5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/snaker-hibernate4/pom.xml
+++ b/snaker-hibernate4/pom.xml
@@ -32,11 +32,11 @@
         </license>
     </licenses>
 
-    <scm>
+    <!--<scm>
         <url>git@github.com:snakerflow/snakerflow.git</url>
         <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
         <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    </scm>-->
 
     <dependencies>
         <dependency>
@@ -100,7 +100,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
+            <!--<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>1.4</version>
@@ -113,7 +113,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin>-->
         </plugins>
     </build>
 </project>

--- a/snaker-jfinal/pom.xml
+++ b/snaker-jfinal/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snaker-parent</artifactId>
         <groupId>com.github.snakerflow</groupId>
-        <version>2.5.1</version>
+        <version>2.5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/snaker-jfinal/pom.xml
+++ b/snaker-jfinal/pom.xml
@@ -31,11 +31,11 @@
         </license>
     </licenses>
 
-    <scm>
+    <!--<scm>
         <url>git@github.com:snakerflow/snakerflow.git</url>
         <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
         <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    </scm>-->
 
     <dependencies>
         <dependency>
@@ -92,7 +92,7 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.4</version>
@@ -105,7 +105,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
         </plugins>
     </build>
 </project>

--- a/snaker-mybatis/pom.xml
+++ b/snaker-mybatis/pom.xml
@@ -33,11 +33,11 @@
         </license>
     </licenses>
 
-    <scm>
+    <!--<scm>
         <url>git@github.com:snakerflow/snakerflow.git</url>
         <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
         <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    </scm>-->
 
     <dependencies>
         <dependency>
@@ -101,7 +101,7 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.4</version>
@@ -114,7 +114,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
         </plugins>
     </build>
 </project>

--- a/snaker-mybatis/pom.xml
+++ b/snaker-mybatis/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snaker-parent</artifactId>
         <groupId>com.github.snakerflow</groupId>
-        <version>2.5.1</version>
+        <version>2.5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/snaker-nutz/pom.xml
+++ b/snaker-nutz/pom.xml
@@ -32,11 +32,11 @@
         </license>
     </licenses>
 
-    <scm>
+    <!--<scm>
         <url>git@github.com:snakerflow/snakerflow.git</url>
         <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
         <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    </scm>-->
 
     <dependencies>
         <dependency>
@@ -111,7 +111,7 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.4</version>
@@ -124,7 +124,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
         </plugins>
     </build>
 </project>

--- a/snaker-nutz/pom.xml
+++ b/snaker-nutz/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>snaker-parent</artifactId>
         <groupId>com.github.snakerflow</groupId>
-        <version>2.5.1</version>
+        <version>2.5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/snaker-quartz/pom.xml
+++ b/snaker-quartz/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snaker-parent</artifactId>
         <groupId>com.github.snakerflow</groupId>
-        <version>2.5.1</version>
+        <version>2.5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/snaker-quartz/pom.xml
+++ b/snaker-quartz/pom.xml
@@ -31,11 +31,11 @@
         </license>
     </licenses>
 
-    <scm>
+    <!--<scm>
         <url>git@github.com:snakerflow/snakerflow.git</url>
         <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
         <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    </scm>-->
 
     <dependencies>
         <dependency>
@@ -94,7 +94,7 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.4</version>
@@ -107,7 +107,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
         </plugins>
     </build>
 </project>

--- a/snaker-spring/pom.xml
+++ b/snaker-spring/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>snaker-parent</artifactId>
         <groupId>com.github.snakerflow</groupId>
-        <version>2.5.1</version>
+        <version>2.5.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/snaker-spring/pom.xml
+++ b/snaker-spring/pom.xml
@@ -31,11 +31,11 @@
         </license>
     </licenses>
 
-    <scm>
+    <!--<scm>
         <url>git@github.com:snakerflow/snakerflow.git</url>
         <connection>scm:git:git@github.com:snakerflow/snakerflow.git</connection>
         <developerConnection>scm:git:git@github.com:snakerflow/snakerflow.git</developerConnection>
-    </scm>
+    </scm>-->
 
     <dependencies>
         <dependency>
@@ -201,7 +201,7 @@
                     </execution>
                 </executions>
             </plugin>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.4</version>
@@ -214,7 +214,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
DB2 Between 语句左右都闭, 导致查询任务列表以及历史任务列表时分页分页错误; 修复方式是 between 的第二个值 -1；
